### PR TITLE
Fix wrong url returned by $filesystem->getUrl() method

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -398,7 +398,11 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $uri = rtrim($this->storageApiUri, '/');
         $path = $this->applyPathPrefix($path);
-        return $uri . '/' . $this->bucket->name() . '/' . $path;
+		if ($uri == 'https://storage.googleapis.com') {
+			return $uri . '/' . $this->bucket->name() . '/' . $path;
+		} else {
+			return $uri . '/' . $path;
+		}      
     }
 
     /**


### PR DESCRIPTION
Fix wrong url returned by `$filesystem->getUrl('my_file.ext')` when using custom domain as bucket name.

E.g bucket name is a custom domain `static.domain.com` which point to directly to the bucket. 
Using null or google cloud storage api url will returns correctly with `https://storage.googleapis.com/static.domain.com/my_file.ext` but when using the custom url `http://static.domain.com`, it returns `http://static.domain.com/static.domain.com/my_file.ext` which is not valid instead of `http://static.domain.com/my_file.ext`.